### PR TITLE
Adding g_console_log and Updating Plutonium Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 This repo contains the T4 Dedicated Server Config for Plutonium T4.
 
 Tutorials on how to use them can be found on:
-* [Plutonium Forum](https://forum.plutonium.pw/topic/6976/)
+* [Plutonium Documentation](https://plutonium.pw/docs/server/t4/setting-up-a-server/)

--- a/main/server.cfg
+++ b/main/server.cfg
@@ -65,8 +65,8 @@ set scr_game_allowkillcam "1"                   // Enable/Disable Killcam
 set g_gravity "800"                             // Gravity
 set g_speed "190"                               // Speed (Default is 190)
 set g_maxDroppedWeapons "32"                    // Number of guns allowed to drop. (Default is 16, we crank this up to match IW4. If that causes issues set it back to 16.)
-set bullet_penetration_affected_by_team true    // Teammate's bodies affect your bullet penetration?
-set g_fixBulletDamageDupe true                  // Prevent clipping players from getting duplicate damage?
+set bullet_penetration_affected_by_team 1    // Teammate's bodies affect your bullet penetration?
+set g_fixBulletDamageDupe 1                  // Prevent clipping players from getting duplicate damage?
 
 
 ///////////////////////////////
@@ -137,6 +137,7 @@ set sv_wwwDlDisconnected "0"                    // Do we treat them as disconnec
 // Server Management/Admin   //
 ///////////////////////////////
 
+set g_console_log "console_mp.log"              // This should be unique per server.
 set g_log "games_mp.log"                        // This should be unique per server.
 set g_logSync "1"                               // This should be left alone if using IW4MAdmin.
 set logfile "2"                                 // This should be left alone if using IW4MAdmin.

--- a/main/server_coop.cfg
+++ b/main/server_coop.cfg
@@ -67,8 +67,8 @@ set g_deadChat "1"                              // Can dead people chat with the
 set scr_game_spectatetype "1"                   // Spectating Type: 0 (None) 1 (Players Only) 2 (Free)
 set g_gravity "800"                             // Gravity
 set g_speed "190"                               // Speed (Default is 190)
-set bullet_penetration_affected_by_team false   // Teammate's bodies affect your bullet penetration?
-set sv_allowFriendlyThrowback true              // Allow friendly grenades to be thrown again?
+set bullet_penetration_affected_by_team 0       // Teammate's bodies affect your bullet penetration?
+set sv_allowFriendlyThrowback 1                 // Allow friendly grenades to be thrown again?
 
 
 ///////////////////////////////
@@ -92,6 +92,7 @@ set sv_wwwDlDisconnected "0"                    // Do we treat them as disconnec
 // Server Management/Admin   //
 ///////////////////////////////
 
+set g_console_log "console_coop.log"            // This should be unique per server.
 set g_log "games_coop.log"                      // This should be unique per server.
 set g_logSync "1"                               // This should be left alone if using IW4MAdmin.
 set logfile "2"                                 // This should be left alone if using IW4MAdmin.

--- a/main/server_zm.cfg
+++ b/main/server_zm.cfg
@@ -60,8 +60,8 @@ set g_deadChat "1"                              // Can dead people chat with the
 set scr_game_spectatetype "1"                   // Spectating Type: 0 (None) 1 (Players Only) 2 (Free)
 set g_gravity "800"                             // Gravity
 set g_speed "190"                               // Speed (Default is 190)
-set bullet_penetration_affected_by_team false   // Teammate's bodies affect your bullet penetration?
-set perk_weapRateEnhanced false                 // Use doubletap 2.0 instead of 1.0?
+set bullet_penetration_affected_by_team 0       // Teammate's bodies affect your bullet penetration?
+set perk_weapRateEnhanced 0                     // Use doubletap 2.0 instead of 1.0?
 
 ///////////////////////////////
 // Server Performance        //
@@ -84,6 +84,7 @@ set sv_wwwDlDisconnected "0"                    // Do we treat them as disconnec
 // Server Management/Admin   //
 ///////////////////////////////
 
+set g_console_log "console_zm.log"              // This should be unique per server.
 set g_log "games_zm.log"                        // This should be unique per server.
 set g_logSync "1"                               // This should be left alone if using IW4MAdmin.
 set logfile "2"                                 // This should be left alone if using IW4MAdmin.


### PR DESCRIPTION
# Config Files
- Replaced true/false with numeric values
- Added the `g_console_log` dvar to avoid the problem of not being able to host multiple servers with `logfile` enabled using the same Plutonium installation on Windows as described in https://forum.plutonium.pw/post/138672
# README.md
- Change link to Pluto docs